### PR TITLE
Add additional where option dropdown combo

### DIFF
--- a/resources/views/formfields/select_dropdown.blade.php
+++ b/resources/views/formfields/select_dropdown.blade.php
@@ -29,11 +29,27 @@
                 $relationshipOptions = $dataTypeContent->$relationshipListMethod();
             } else {
                 $relationshipClass = $dataTypeContent->{camel_case($row->field)}()->getRelated();
-                if (isset($options->relationship->where)) {
-                    $relationshipOptions = $relationshipClass::where(
-                        $options->relationship->where[0],
-                        $options->relationship->where[1]
-                    )->get();
+               if (isset($options->relationship->where)) {
+                    if (count($options->relationship->where) == 2) {
+                        $relationshipOptions = $relationshipClass::where(
+                                $options->relationship->where[0],
+                                $options->relationship->where[1]
+                        )->get();
+                    } else {
+                        if (count($options->relationship->where) == 3) {
+                            $relationshipOptions = $relationshipClass::where(
+                                    $options->relationship->where[0],
+                                    $options->relationship->where[1],
+                                    $options->relationship->where[2]
+                            )->get();
+                        } else {
+                            $relationshipOptions = $relationshipClass::where(
+                                    'id',
+                                    $options->relationship->where[0]
+                            )->get();
+                        }
+                    }
+
                 } else {
                     $relationshipOptions = $relationshipClass::all();
                 }


### PR DESCRIPTION
Hello, I want to make a change in the conditions of the  dropdown for the "where" option taking into account the 3 options that gives datatable component.
1 variable looking for the id directly 

> ```
> {
>     "relationship": {
>         "key": "id",
>         "label": "name",
>         "where": [
>             "1"
>         ]
>     }
> }
> ```

```
$model= DB::table('table')
                 ->where('id',  1)
                 ->get();
```

2 variables to compare two fields with "=" (Existing option)

> ```
> {
>     "relationship": {
>         "key": "id",
>         "label": "name",
>         "where": [
>             "parent_id",
>             "1"
>         ]
>     }
> }
> ```
```
$model= DB::table('table')
                 ->where('parent_id',  1)
                 ->get();
```
 and another option of 3 variables to add the type of condition.

> ```
> {
>     "relationship": {
>         "key": "id",
>         "label": "name",
>         "where": [
>             "name",
>             "like"
>             "Star%"
>         ]
>     }
> }
> ```
> 
$model= DB::table('table')
                 ->where('name', 'like', 'Star%')
                 ->get();
```

Thank!!!